### PR TITLE
Add new @beemo/dependency-graph package

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 #### 🚀 New
 
+- Added a new package,
+  [@beemo/dependency-graph](https://www.npmjs.com/package/@beemo/dependency-graph), to handle the
+  dependency resolution.
 - Added a `none` strategy option to `Driver`s. With this strategy, the consumer will need to
   manually create a config file.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@beemo/dependency-graph": "^0.0.0",
     "@boost/core": "^1.9.1",
     "@types/execa": "^0.9.0",
     "@types/fs-extra": "^5.0.5",

--- a/packages/core/src/ConfigureRoutine.ts
+++ b/packages/core/src/ConfigureRoutine.ts
@@ -25,9 +25,10 @@ export default class ConfigureRoutine<T extends ConfigContext = ConfigContext> e
    */
   setupConfigFiles() {
     const names = [...this.context.drivers].reverse().map(driver => {
-      const routine = new CreateConfigRoutine(driver.name, driver.metadata.configName, { driver });
+      const routine = new CreateConfigRoutine<T>(driver.name, driver.metadata.configName, {
+        driver,
+      });
 
-      // @ts-ignore Not sure why this errors
       this.pipe(routine);
 
       return driver.name;

--- a/packages/core/src/configure/CreateConfigRoutine.ts
+++ b/packages/core/src/configure/CreateConfigRoutine.ts
@@ -16,8 +16,8 @@ export interface CreateConfigOptions {
   driver: Driver;
 }
 
-export default class CreateConfigRoutine extends Routine<
-  ConfigContext,
+export default class CreateConfigRoutine<T extends ConfigContext> extends Routine<
+  T,
   BeemoTool,
   CreateConfigOptions
 > {

--- a/packages/core/src/configure/CreateConfigRoutine.ts
+++ b/packages/core/src/configure/CreateConfigRoutine.ts
@@ -16,8 +16,8 @@ export interface CreateConfigOptions {
   driver: Driver;
 }
 
-export default class CreateConfigRoutine<T extends ConfigContext> extends Routine<
-  T,
+export default class CreateConfigRoutine<Ctx extends ConfigContext> extends Routine<
+  Ctx,
   BeemoTool,
   CreateConfigOptions
 > {
@@ -67,7 +67,7 @@ export default class CreateConfigRoutine<T extends ConfigContext> extends Routin
   /**
    * Copy configuration file from module.
    */
-  async copyConfigFile(context: ConfigContext): Promise<string> {
+  async copyConfigFile(context: Ctx): Promise<string> {
     const { metadata, name } = this.options.driver;
     const configLoader = new ConfigLoader(this.tool);
     const sourcePath = this.getConfigPath(configLoader);
@@ -97,7 +97,7 @@ export default class CreateConfigRoutine<T extends ConfigContext> extends Routin
   /**
    * Create a temporary configuration file or pass as an option.
    */
-  async createConfigFile(context: ConfigContext, config: object): Promise<string> {
+  async createConfigFile(context: Ctx, config: object): Promise<string> {
     const { metadata, name } = this.options.driver;
     const configPath = path.join(context.cwd, metadata.configName);
 
@@ -117,10 +117,7 @@ export default class CreateConfigRoutine<T extends ConfigContext> extends Routin
   /**
    * Extract configuration from "beemo.<driver>" within the local project's package.json.
    */
-  extractConfigFromPackage(
-    context: ConfigContext,
-    prevConfigs: ConfigObject[],
-  ): Promise<ConfigObject[]> {
+  extractConfigFromPackage(context: Ctx, prevConfigs: ConfigObject[]): Promise<ConfigObject[]> {
     const { name } = this.options.driver;
     const { config } = this.tool;
     const configs = [...prevConfigs];
@@ -185,7 +182,7 @@ export default class CreateConfigRoutine<T extends ConfigContext> extends Routin
   /**
    * Merge multiple configuration sources using the current driver.
    */
-  mergeConfigs(context: ConfigContext, configs: ConfigObject[]): Promise<ConfigObject> {
+  mergeConfigs(context: Ctx, configs: ConfigObject[]): Promise<ConfigObject> {
     const { name } = this.options.driver;
 
     this.debug('Merging %s config from %d sources', chalk.green(name), configs.length);
@@ -219,10 +216,7 @@ export default class CreateConfigRoutine<T extends ConfigContext> extends Routin
    * Load config from the provider configuration module
    * and from the local configs/ folder in the consumer.
    */
-  loadConfigFromSources(
-    context: ConfigContext,
-    prevConfigs: ConfigObject[],
-  ): Promise<ConfigObject[]> {
+  loadConfigFromSources(context: Ctx, prevConfigs: ConfigObject[]): Promise<ConfigObject[]> {
     const configLoader = new ConfigLoader(this.tool);
     const modulePath = this.getConfigPath(configLoader);
     const localPath = this.getConfigPath(configLoader, true);
@@ -244,7 +238,7 @@ export default class CreateConfigRoutine<T extends ConfigContext> extends Routin
   /**
    * Reference configuration file from module using a require statement.
    */
-  referenceConfigFile(context: ConfigContext): Promise<string> {
+  referenceConfigFile(context: Ctx): Promise<string> {
     const { metadata, name } = this.options.driver;
     const configLoader = new ConfigLoader(this.tool);
     const sourcePath = this.getConfigPath(configLoader);
@@ -275,7 +269,7 @@ export default class CreateConfigRoutine<T extends ConfigContext> extends Routin
   /**
    * Set environment variables defined by the driver.
    */
-  setEnvVars(context: ConfigContext, configs: ConfigObject[]): Promise<any> {
+  setEnvVars(context: Ctx, configs: ConfigObject[]): Promise<any> {
     const { env } = this.options.driver.options;
 
     // TODO: This may cause collisions, isolate in a child process?

--- a/packages/core/src/execute/BaseRoutine.ts
+++ b/packages/core/src/execute/BaseRoutine.ts
@@ -93,7 +93,6 @@ export default abstract class BaseRoutine<Ctx extends Context> extends Routine<C
     const other: Routine<Ctx, BeemoTool>[] = [];
 
     const handler = (node: TreeNode<WorkspacePackageConfig>) => {
-      // @ts-ignore
       const routine = this.routines.find(route => route.key === node.package.workspace.packageName);
 
       if (routine) {

--- a/packages/core/src/execute/BaseRoutine.ts
+++ b/packages/core/src/execute/BaseRoutine.ts
@@ -96,10 +96,10 @@ export default abstract class BaseRoutine<Ctx extends Context> extends Routine<C
       const routine = this.routines.find(route => route.key === node.package.workspace.packageName);
 
       if (routine) {
-        if (node.leaf) {
-          other.push(routine);
-        } else {
+        if (node.nodes) {
           priority.push(routine);
+        } else {
+          other.push(routine);
         }
       }
 

--- a/packages/core/src/execute/BaseRoutine.ts
+++ b/packages/core/src/execute/BaseRoutine.ts
@@ -1,4 +1,5 @@
 import { Routine, WorkspacePackageConfig } from '@boost/core';
+import Graph, { TreeNode } from '@beemo/dependency-graph';
 import Context from '../contexts/Context';
 import isPatternMatch from '../utils/isPatternMatch';
 import { BeemoTool } from '../types';
@@ -87,70 +88,28 @@ export default abstract class BaseRoutine<Ctx extends Context> extends Routine<C
       };
     }
 
-    const packages: { [name: string]: WorkspacePackageConfig & CustomConfig } = {};
-    const depCounts: { [name: string]: { count: number; package: WorkspacePackageConfig } } = {};
-
-    function countDep(name: string) {
-      if (depCounts[name]) {
-        depCounts[name].count += 1;
-      } else {
-        depCounts[name] = {
-          count: packages[name].priority || 1,
-          package: packages[name],
-        };
-      }
-    }
-
-    // Create a mapping of package names within all workspaces
-    this.workspacePackages.forEach(pkg => {
-      packages[pkg.name] = pkg;
-
-      // Count it immediately, as it may not be dependend on
-      if (pkg.priority) {
-        countDep(pkg.name);
-      }
-    });
-
-    // Determine dependend on packages by resolving the graph and incrementing counts
-    this.workspacePackages.forEach(pkg => {
-      const deps = {
-        ...pkg.dependencies,
-        ...pkg.peerDependencies,
-      };
-
-      Object.keys(deps).forEach(depName => {
-        if (packages[depName]) {
-          countDep(depName);
-        }
-      });
-    });
-
-    // Order by highest count
-    const orderedDeps = Object.values(depCounts)
-      .sort((a, b) => b.count - a.count)
-      .map(dep => dep.package);
-
-    // Extract dependents in order
+    const tree = new Graph(this.workspacePackages).resolveTree();
     const priority: Routine<Ctx, BeemoTool>[] = [];
-
-    orderedDeps.forEach(pkg => {
-      const routine = this.routines.find(route => route.key === pkg.workspace.packageName);
-
-      if (routine) {
-        priority.push(routine);
-      }
-    });
-
-    // Extract dependers
     const other: Routine<Ctx, BeemoTool>[] = [];
 
-    this.routines.forEach(routine => {
-      const dependency = orderedDeps.find(dep => dep.workspace.packageName === routine.key);
+    const handler = (node: TreeNode<WorkspacePackageConfig>) => {
+      // @ts-ignore
+      const routine = this.routines.find(route => route.key === node.package.workspace.packageName);
 
-      if (!dependency) {
-        other.push(routine);
+      if (routine) {
+        if (node.leaf) {
+          other.push(routine);
+        } else {
+          priority.push(routine);
+        }
       }
-    });
+
+      if (node.nodes) {
+        node.nodes.forEach(childNode => handler(childNode));
+      }
+    };
+
+    tree.nodes.forEach(node => handler(node));
 
     return {
       other,

--- a/packages/core/tests/configure/CreateConfigRoutine.test.ts
+++ b/packages/core/tests/configure/CreateConfigRoutine.test.ts
@@ -24,7 +24,7 @@ describe('CreateConfigRoutine', () => {
   const oldExistsSync = fs.existsSync;
   const oldWriteFile = fs.writeFile;
   const oldCopy = fs.copy;
-  let routine: CreateConfigRoutine;
+  let routine: CreateConfigRoutine<any>;
   let driver: Driver;
   let tool: BeemoTool;
 

--- a/packages/core/tests/execute/BaseRoutine.test.ts
+++ b/packages/core/tests/execute/BaseRoutine.test.ts
@@ -286,7 +286,7 @@ describe('BaseExecuteRoutine', () => {
       };
 
       expect(routine.orderByWorkspacePriorityGraph()).toEqual({
-        other: [primary, foo, baz, qux],
+        other: [foo, primary, baz, qux],
         priority: [bar],
       });
     });
@@ -298,7 +298,7 @@ describe('BaseExecuteRoutine', () => {
       };
 
       expect(routine.orderByWorkspacePriorityGraph()).toEqual({
-        other: [primary, foo, baz, qux],
+        other: [foo, primary, baz, qux],
         priority: [bar],
       });
     });

--- a/packages/core/tests/execute/BaseRoutine.test.ts
+++ b/packages/core/tests/execute/BaseRoutine.test.ts
@@ -155,7 +155,8 @@ describe('BaseExecuteRoutine', () => {
       it('serializes priority routines before pooling other routines', async () => {
         routine.serializeRoutines = jest.fn(() => Promise.resolve());
         routine.poolRoutines = jest.fn(() => Promise.resolve({ errors: [], results: [] }));
-        routine.workspacePackages[1].peerDependencies = {
+        // primary -> foo
+        routine.workspacePackages[0].peerDependencies = {
           '@scope/foo': '1.0.0',
         };
 
@@ -279,6 +280,7 @@ describe('BaseExecuteRoutine', () => {
     });
 
     it('prioritizes based on peerDependencies', () => {
+      // foo -> bar
       routine.workspacePackages[1].peerDependencies = {
         '@scope/bar': '1.0.0',
       };
@@ -290,6 +292,7 @@ describe('BaseExecuteRoutine', () => {
     });
 
     it('prioritizes based on dependencies', () => {
+      // foo -> bar
       routine.workspacePackages[1].dependencies = {
         '@scope/bar': '1.0.0',
       };
@@ -301,43 +304,24 @@ describe('BaseExecuteRoutine', () => {
     });
 
     it('sorts priority based on dependency count', () => {
+      // bar -> primary
       routine.workspacePackages[2].peerDependencies = {
         '@scope/primary': '2.0.0',
       };
 
+      // foo -> bar
       routine.workspacePackages[1].dependencies = {
         '@scope/bar': '1.0.0',
       };
 
+      // qux -> bar
       routine.workspacePackages[4].peerDependencies = {
         '@scope/bar': '1.0.0',
       };
 
       expect(routine.orderByWorkspacePriorityGraph()).toEqual({
-        other: [foo, baz, qux],
-        priority: [bar, primary],
-      });
-    });
-
-    it('sorts priority by taking `priority` package option into account', () => {
-      routine.workspacePackages[2].peerDependencies = {
-        '@scope/primary': '2.0.0',
-      };
-
-      routine.workspacePackages[1].dependencies = {
-        '@scope/bar': '1.0.0',
-      };
-
-      routine.workspacePackages[4].priority = 3;
-      routine.workspacePackages[4].peerDependencies = {
-        '@scope/bar': '1.0.0',
-      };
-
-      routine.workspacePackages[0].priority = 100;
-
-      expect(routine.orderByWorkspacePriorityGraph()).toEqual({
-        other: [foo, baz],
-        priority: [primary, qux, bar],
+        other: [foo, qux, baz],
+        priority: [primary, bar],
       });
     });
   });

--- a/packages/dependency-graph/.npmignore
+++ b/packages/dependency-graph/.npmignore
@@ -1,0 +1,6 @@
+*.log
+dist/
+src/
+tests/
+types/
+tsconfig.json

--- a/packages/dependency-graph/CHANGELOG.md
+++ b/packages/dependency-graph/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 1.0.0
+
+#### 🎉 Release
+
+- Initial release!

--- a/packages/dependency-graph/LICENSE
+++ b/packages/dependency-graph/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2019 Miles Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/dependency-graph/README.md
+++ b/packages/dependency-graph/README.md
@@ -1,0 +1,19 @@
+# Dependency Graph
+
+[![Build Status](https://travis-ci.org/beemojs/beemo.svg?branch=master)](https://travis-ci.org/beemojs/beemo)
+[![npm version](https://badge.fury.io/js/%40beemo%2Fdependency-graph.svg)](https://www.npmjs.com/package/@beemo/dependency-graph)
+[![npm deps](https://david-dm.org/beemojs/beemo.svg?path=packages/dependency-graph)](https://www.npmjs.com/package/@beemo/dependency-graph)
+
+Generate a dependency graph based on a list of packages.
+
+## Installation
+
+```
+yarn add @beemo/dependency-graph
+// Or
+npm install @beemo/dependency-graph --save
+```
+
+## Documentation
+
+TODO

--- a/packages/dependency-graph/README.md
+++ b/packages/dependency-graph/README.md
@@ -17,8 +17,8 @@ npm install @beemo/dependency-graph --save
 
 ## Documentation
 
-To begin, instantiate an instance of `Graph`, which accepts a list of `package.json` objects as the
-first argument.
+To begin, instantiate an instance of `Graph`, which accepts a list of optional `package.json`
+objects as the first argument.
 
 ```ts
 import Graph from '@beemo/dependency-graph';
@@ -36,7 +36,8 @@ const graph = new Graph([
 ]);
 ```
 
-Alternatively, `package.json` objects can be added dynamically using `Graph#addPackage`.
+Alternatively, `package.json` objects can be added dynamically using `Graph#addPackage` or
+`Graph#addPackages`.
 
 ```ts
 graph.addPackage({
@@ -48,13 +49,13 @@ graph.addPackage({
 });
 ```
 
-Once all packages have been defined, we can generate a graph using `Graph#resolveInOrder`, which
-returns an array of packages in the order by most depended on, or with `Graph#resolveTree`, which
+Once all packages have been defined, we can generate a graph using `Graph#resolveList`, which
+returns an array of packages in order of most depended on, or with `Graph#resolveTree`, which
 returns a tree of nodes based on the graph.
 
 ```ts
 // List of packages
-graph.resolveInOrder().forEach(pkg => {
+graph.resolveList().forEach(pkg => {
   console.log(pkg.name);
 });
 

--- a/packages/dependency-graph/README.md
+++ b/packages/dependency-graph/README.md
@@ -4,7 +4,8 @@
 [![npm version](https://badge.fury.io/js/%40beemo%2Fdependency-graph.svg)](https://www.npmjs.com/package/@beemo/dependency-graph)
 [![npm deps](https://david-dm.org/beemojs/beemo.svg?path=packages/dependency-graph)](https://www.npmjs.com/package/@beemo/dependency-graph)
 
-Generate a dependency graph based on a list of packages.
+Generate a dependency graph for a list of packages, based on their defined `dependencies` and
+`peerDependencies`.
 
 ## Installation
 
@@ -16,4 +17,56 @@ npm install @beemo/dependency-graph --save
 
 ## Documentation
 
-TODO
+To begin, instantiate an instance of `Graph`, which accepts a list of `package.json` objects as the
+first argument.
+
+```ts
+import Graph from '@beemo/dependency-graph';
+
+const graph = new Graph([
+  {
+    name: '@beemo/core',
+  },
+  {
+    name: '@beemo/cli',
+    dependencies: {
+      '@beemo/core': '^1.0.0',
+    },
+  },
+]);
+```
+
+Alternatively, `package.json` objects can be added dynamically using `Graph#addPackage`.
+
+```ts
+graph.addPackage({
+  name: '@beemo/driver-jest',
+  peerDependencies: {
+    '@beemo/core': '^1.0.0',
+    '@beemo/driver-babel': '^1.0.0',
+  },
+});
+```
+
+Once all packages have been defined, we can generate a graph using `Graph#resolveInOrder`, which
+returns an array of packages in the order by most depended on, or with `Graph#resolveTree`, which
+returns a tree of nodes based on the graph.
+
+```ts
+// List of packages
+graph.resolveInOrder().forEach(pkg => {
+  console.log(pkg.name);
+});
+
+// Tree of nodes
+graph.resolveTree().nodes.forEach(node => {
+  console.log(node.package.name);
+
+  if (node.nodes) {
+    // Dependents
+  }
+});
+```
+
+> Will only resolve and return packages that have been defined. Will _not_ return non-defined
+> packages found in `dependencies` and `peerDependencies`.

--- a/packages/dependency-graph/package.json
+++ b/packages/dependency-graph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@beemo/dependency-graph",
   "version": "0.0.0",
-  "description": "Generate a dependency graph based on a list of packages.",
+  "description": "Generate a dependency graph for a list of packages, based on their defined `dependencies` and `peerDependencies`.",
   "keywords": [
     "beemo",
     "dependency",

--- a/packages/dependency-graph/package.json
+++ b/packages/dependency-graph/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@beemo/dependency-graph",
+  "version": "0.0.0",
+  "description": "Generate a dependency graph based on a list of packages.",
+  "keywords": [
+    "beemo",
+    "dependency",
+    "graph"
+  ],
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "engines": {
+    "node": ">=8.9.0"
+  },
+  "repository": "https://github.com/beemojs/beemo/tree/master/packages/driver-babel",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/dependency-graph/src/Graph.ts
+++ b/packages/dependency-graph/src/Graph.ts
@@ -9,9 +9,7 @@ export default class Graph<T extends PackageConfig = PackageConfig> {
   protected packages: Map<string, T> = new Map();
 
   constructor(packages: T[] = []) {
-    packages.forEach(pkg => {
-      this.addPackage(pkg);
-    });
+    this.addPackages(packages);
   }
 
   /**
@@ -34,10 +32,21 @@ export default class Graph<T extends PackageConfig = PackageConfig> {
   }
 
   /**
-   * Resolve the dependency graph and return an array of all package configs
-   * in the order they are depended on.
+   * Add multiple packages.
    */
-  resolveInOrder(): T[] {
+  addPackages(packages: T[] = []): this {
+    packages.forEach(pkg => {
+      this.addPackage(pkg);
+    });
+
+    return this;
+  }
+
+  /**
+   * Resolve the dependency graph and return a list of all
+   * `package.json` objects in the order they are depended on.
+   */
+  resolveList(): T[] {
     this.mapDependencies();
 
     const order: Set<T> = new Set();
@@ -70,8 +79,8 @@ export default class Graph<T extends PackageConfig = PackageConfig> {
   }
 
   /**
-   * Resolve the dependency graph and return a tree or nodes for all
-   * package configs and their dependency mappings.
+   * Resolve the dependency graph and return a tree of nodes for all
+   * `package.json` objects and their dependency mappings.
    */
   resolveTree(): Tree<T> {
     this.mapDependencies();

--- a/packages/dependency-graph/src/Graph.ts
+++ b/packages/dependency-graph/src/Graph.ts
@@ -1,0 +1,176 @@
+import Node from './Node';
+import { PackageConfig, TreeRoot, TreeNode } from './types';
+
+export default class Graph {
+  protected cache: Map<string, Node> = new Map();
+
+  protected mapped: boolean = false;
+
+  protected nodes: Set<Node> = new Set();
+
+  protected packages: Map<string, PackageConfig> = new Map();
+
+  constructor(packages: PackageConfig[] = []) {
+    packages.forEach(pkg => {
+      this.addPackage(pkg);
+    });
+  }
+
+  /**
+   * Add a package by name with an associated `package.json` object.
+   * Will map a dependency between the package and its dependees
+   * found in `dependencies` and `peerDependencies`.
+   */
+  addPackage(pkg: PackageConfig): this {
+    if (this.mapped) {
+      this.resetNodes();
+    }
+
+    // Cache package data for later use
+    this.packages.set(pkg.name, pkg);
+
+    // Add node to the graph
+    this.addNode(pkg.name);
+
+    return this;
+  }
+
+  resolveInOrder(): PackageConfig[] {
+    this.mapDependencies();
+
+    const order: Set<PackageConfig> = new Set();
+    const resolve = (nodes: Set<Node>) => {
+      // Add parent nodes first
+      nodes.forEach(node => {
+        const pkg = this.packages.get(node.name);
+
+        // Only include nodes that have package data
+        if (pkg) {
+          order.add(pkg);
+        }
+      });
+
+      // Add children after parents so order is preserved
+      nodes.forEach(node => {
+        resolve(node.dependents);
+      });
+    };
+
+    resolve(this.nodes);
+
+    return Array.from(order);
+  }
+
+  resolveTree(): TreeRoot {
+    this.mapDependencies();
+
+    const seen: Set<string> = new Set();
+    const resolve = (node: Node, tree: TreeRoot | TreeNode) => {
+      if (seen.has(node.name)) {
+        return;
+      }
+
+      const pkg = this.packages.get(node.name);
+
+      if (!pkg) {
+        return;
+      }
+
+      const branch: TreeNode = {
+        package: pkg,
+      };
+
+      if (node.dependents.size === 0) {
+        branch.leaf = true;
+      }
+
+      node.dependents.forEach(child => {
+        resolve(child, branch);
+      });
+
+      if (tree.nodes) {
+        tree.nodes.push(branch);
+      } else {
+        tree.nodes = [branch];
+      }
+
+      seen.add(node.name);
+    };
+
+    const trunk: TreeRoot = {
+      nodes: [],
+      root: true,
+    };
+
+    this.nodes.forEach(node => resolve(node, trunk));
+
+    return trunk;
+  }
+
+  /**
+   * Add a node for the defined package name.
+   */
+  protected addNode(name: string) {
+    const node = new Node(name);
+
+    // Cache node for constant lookups
+    this.cache.set(name, node);
+
+    // Add to the root as it has no parent yet
+    this.nodes.add(node);
+  }
+
+  /**
+   * Map dependencies between all currently registered packages.
+   */
+  protected mapDependencies() {
+    if (this.mapped) {
+      return;
+    }
+
+    this.mapped = true;
+    this.packages.forEach(pkg => {
+      Object.keys({
+        ...pkg.dependencies,
+        ...pkg.peerDependencies,
+      }).forEach(depName => {
+        this.mapDependency(pkg.name, depName);
+      });
+    });
+  }
+
+  /**
+   * Map a dependency link for a dependent (child) depending on a requirement (parent).
+   * Will link the parent and child accordingly, and will remove the child
+   * from the root if it exists.
+   */
+  protected mapDependency(dependentName: string, requirementName: string) {
+    const requirement = this.cache.get(requirementName);
+    const dependent = this.cache.get(dependentName);
+
+    if (!requirement || !dependent) {
+      return;
+    }
+
+    // Child depends on parent
+    dependent.requirements.add(requirement);
+
+    // Parent is a dependee of child
+    requirement.dependents.add(dependent);
+
+    // Remove from the root
+    this.nodes.delete(dependent);
+  }
+
+  /**
+   * Remove all current nodes in the graph and add new root nodes for each package.
+   */
+  protected resetNodes() {
+    this.mapped = false;
+    this.cache = new Map();
+    this.nodes = new Set();
+    this.packages.forEach(pkg => {
+      this.addNode(pkg.name);
+    });
+  }
+}

--- a/packages/dependency-graph/src/Graph.ts
+++ b/packages/dependency-graph/src/Graph.ts
@@ -35,6 +35,10 @@ export default class Graph<T extends PackageConfig = PackageConfig> {
     return this;
   }
 
+  /**
+   * Resolve the dependency graph and return an array of all package configs
+   * in the order they are depended on.
+   */
   resolveInOrder(): T[] {
     this.mapDependencies();
 
@@ -61,6 +65,10 @@ export default class Graph<T extends PackageConfig = PackageConfig> {
     return Array.from(order);
   }
 
+  /**
+   * Resolve the dependency graph and return a tree or nodes for all
+   * package configs and their dependency mappings.
+   */
   resolveTree(): Tree<T> {
     this.mapDependencies();
 

--- a/packages/dependency-graph/src/Graph.ts
+++ b/packages/dependency-graph/src/Graph.ts
@@ -134,10 +134,8 @@ export default class Graph<T extends PackageConfig = PackageConfig> {
    * Add a node for the defined package name.
    */
   protected addNode(name: string) {
-    const node = new Node(name);
-
     // Cache node for constant lookups
-    this.nodes.set(name, node);
+    this.nodes.set(name, new Node(name));
   }
 
   /**

--- a/packages/dependency-graph/src/Node.ts
+++ b/packages/dependency-graph/src/Node.ts
@@ -1,0 +1,11 @@
+export default class Node {
+  name: string;
+
+  dependents: Set<Node> = new Set();
+
+  requirements: Set<Node> = new Set();
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}

--- a/packages/dependency-graph/src/index.ts
+++ b/packages/dependency-graph/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @copyright   2017-2019, Miles Johnson
+ * @license     https://opensource.org/licenses/MIT
+ */
+
+import Graph from './Graph';
+import Node from './Node';
+
+export * from './types';
+
+export { Node };
+export default Graph;

--- a/packages/dependency-graph/src/types.ts
+++ b/packages/dependency-graph/src/types.ts
@@ -1,0 +1,21 @@
+export interface DependencyMap {
+  [module: string]: string;
+}
+
+export interface PackageConfig {
+  name: string;
+  dependencies?: DependencyMap;
+  devDependencies?: DependencyMap;
+  peerDependencies?: DependencyMap;
+}
+
+export interface TreeNode {
+  leaf?: boolean;
+  nodes?: TreeNode[];
+  package: PackageConfig;
+}
+
+export interface TreeRoot {
+  nodes: TreeNode[];
+  root: boolean;
+}

--- a/packages/dependency-graph/src/types.ts
+++ b/packages/dependency-graph/src/types.ts
@@ -10,7 +10,6 @@ export interface PackageConfig {
 }
 
 export interface TreeNode<T extends PackageConfig> {
-  leaf?: boolean;
   nodes?: TreeNode<T>[];
   package: T;
 }

--- a/packages/dependency-graph/src/types.ts
+++ b/packages/dependency-graph/src/types.ts
@@ -9,13 +9,13 @@ export interface PackageConfig {
   peerDependencies?: DependencyMap;
 }
 
-export interface TreeNode {
+export interface TreeNode<T extends PackageConfig> {
   leaf?: boolean;
-  nodes?: TreeNode[];
-  package: PackageConfig;
+  nodes?: TreeNode<T>[];
+  package: T;
 }
 
-export interface TreeRoot {
-  nodes: TreeNode[];
+export interface Tree<T extends PackageConfig> {
+  nodes: TreeNode<T>[];
   root: boolean;
 }

--- a/packages/dependency-graph/tests/Graph.test.ts
+++ b/packages/dependency-graph/tests/Graph.test.ts
@@ -1,0 +1,259 @@
+import path from 'path';
+import glob from 'fast-glob';
+import Graph from '../src/Graph';
+import { PackageConfig } from '../src/types';
+
+function getBeemoPackages() {
+  const pkgs: { [key: string]: PackageConfig } = {};
+
+  glob.sync(path.join(__dirname, '../../*/package.json')).forEach(pkgPath => {
+    // eslint-disable-next-line
+    const pkg = require(String(pkgPath));
+    pkgs[pkg.name] = pkg;
+  });
+
+  return pkgs;
+}
+
+describe('Graph', () => {
+  it('graphs Beemo dependencies correctly ', () => {
+    const pkgs = getBeemoPackages();
+    const graph = new Graph(Object.values(pkgs));
+
+    expect(graph.resolveInOrder()).toEqual([
+      pkgs['@beemo/core'],
+      pkgs['@beemo/dependency-graph'],
+      pkgs['@beemo/cli'],
+      pkgs['@beemo/driver-babel'],
+      pkgs['@beemo/driver-eslint'],
+      pkgs['@beemo/driver-flow'],
+      pkgs['@beemo/driver-jest'],
+      pkgs['@beemo/driver-mocha'],
+      pkgs['@beemo/driver-prettier'],
+      pkgs['@beemo/driver-typescript'],
+      pkgs['@beemo/driver-webpack'],
+    ]);
+
+    expect(graph.resolveTree()).toEqual({
+      root: true,
+      nodes: [
+        {
+          package: pkgs['@beemo/core'],
+          nodes: [
+            {
+              leaf: true,
+              package: pkgs['@beemo/cli'],
+            },
+            {
+              package: pkgs['@beemo/driver-babel'],
+              nodes: [
+                {
+                  leaf: true,
+                  package: pkgs['@beemo/driver-jest'],
+                },
+              ],
+            },
+            {
+              leaf: true,
+              package: pkgs['@beemo/driver-eslint'],
+            },
+            {
+              leaf: true,
+              package: pkgs['@beemo/driver-flow'],
+            },
+            {
+              leaf: true,
+              package: pkgs['@beemo/driver-mocha'],
+            },
+            {
+              leaf: true,
+              package: pkgs['@beemo/driver-prettier'],
+            },
+            {
+              leaf: true,
+              package: pkgs['@beemo/driver-typescript'],
+            },
+            {
+              leaf: true,
+              package: pkgs['@beemo/driver-webpack'],
+            },
+          ],
+        },
+        {
+          leaf: true,
+          package: pkgs['@beemo/dependency-graph'],
+        },
+      ],
+    });
+  });
+
+  it.skip('handles circular cycles', () => {
+    const graph = new Graph([
+      { name: 'foo', dependencies: { bar: '0.0.0' } },
+      { name: 'bar', dependencies: { foo: '0.0.0' } },
+    ]);
+
+    console.log(graph);
+
+    expect(graph.resolveInOrder()).toEqual([]);
+    expect(graph.resolveTree()).toEqual({
+      root: true,
+      nodes: [],
+    });
+  });
+
+  it('returns an empty array when no packages are defined', () => {
+    const graph = new Graph();
+
+    expect(graph.resolveInOrder()).toEqual([]);
+    expect(graph.resolveTree()).toEqual({
+      root: true,
+      nodes: [],
+    });
+  });
+
+  it('places all nodes at the root if they do not relate to each other', () => {
+    const graph = new Graph([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]);
+
+    expect(graph.resolveInOrder()).toEqual([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]);
+    expect(graph.resolveTree()).toEqual({
+      root: true,
+      nodes: [
+        {
+          leaf: true,
+          package: { name: 'foo' },
+        },
+        {
+          leaf: true,
+          package: { name: 'bar' },
+        },
+        {
+          leaf: true,
+          package: { name: 'baz' },
+        },
+      ],
+    });
+  });
+
+  it('maps dependencies between 2 packages', () => {
+    const graph = new Graph([{ name: 'foo' }, { name: 'bar', dependencies: { foo: '0.0.0' } }]);
+
+    expect(graph.resolveInOrder()).toEqual([
+      { name: 'foo' },
+      { name: 'bar', dependencies: { foo: '0.0.0' } },
+    ]);
+    expect(graph.resolveTree()).toEqual({
+      root: true,
+      nodes: [
+        {
+          package: { name: 'foo' },
+          nodes: [
+            {
+              leaf: true,
+              package: { name: 'bar', dependencies: { foo: '0.0.0' } },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('maps dependencies between 2 packages (reverse order + peer deps)', () => {
+    const graph = new Graph([{ name: 'foo', peerDependencies: { bar: '0.0.0' } }, { name: 'bar' }]);
+
+    expect(graph.resolveInOrder()).toEqual([
+      { name: 'bar' },
+      { name: 'foo', peerDependencies: { bar: '0.0.0' } },
+    ]);
+    expect(graph.resolveTree()).toEqual({
+      root: true,
+      nodes: [
+        {
+          package: { name: 'bar' },
+          nodes: [
+            {
+              leaf: true,
+              package: { name: 'foo', peerDependencies: { bar: '0.0.0' } },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('maps dependencies between 3 packages', () => {
+    const graph = new Graph([
+      { name: 'foo', dependencies: { baz: '0.0.0' } },
+      { name: 'bar' },
+      { name: 'baz' },
+    ]);
+
+    expect(graph.resolveInOrder()).toEqual([
+      { name: 'bar' },
+      { name: 'baz' },
+      { name: 'foo', dependencies: { baz: '0.0.0' } },
+    ]);
+    expect(graph.resolveTree()).toEqual({
+      root: true,
+      nodes: [
+        {
+          leaf: true,
+          package: { name: 'bar' },
+        },
+        {
+          package: { name: 'baz' },
+          nodes: [
+            {
+              leaf: true,
+              package: { name: 'foo', dependencies: { baz: '0.0.0' } },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('maps 3 layers deep', () => {
+    const graph = new Graph([
+      { name: 'foo', dependencies: { bar: '0.0.0' } },
+      { name: 'bar', dependencies: { baz: '0.0.0' } },
+      { name: 'baz' },
+    ]);
+
+    expect(graph.resolveInOrder()).toEqual([
+      { name: 'baz' },
+      { name: 'bar', dependencies: { baz: '0.0.0' } },
+      { name: 'foo', dependencies: { bar: '0.0.0' } },
+    ]);
+    expect(graph.resolveTree()).toEqual({
+      root: true,
+      nodes: [
+        {
+          package: { name: 'baz' },
+          nodes: [
+            {
+              package: { name: 'bar', dependencies: { baz: '0.0.0' } },
+              nodes: [{ leaf: true, package: { name: 'foo', dependencies: { bar: '0.0.0' } } }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('resets the graph when a package is added after resolution', () => {
+    const graph = new Graph([{ name: 'foo' }, { name: 'bar' }]);
+
+    expect(graph.resolveInOrder()).toEqual([{ name: 'foo' }, { name: 'bar' }]);
+
+    graph.addPackage({ name: 'qux', dependencies: { baz: '0.0.0' } });
+    graph.addPackage({ name: 'baz', dependencies: { foo: '0.0.0' } });
+
+    expect(graph.resolveInOrder()).toEqual([
+      { name: 'foo' },
+      { name: 'bar' },
+      { name: 'baz', dependencies: { foo: '0.0.0' } },
+      { name: 'qux', dependencies: { baz: '0.0.0' } },
+    ]);
+  });
+});

--- a/packages/dependency-graph/tests/Graph.test.ts
+++ b/packages/dependency-graph/tests/Graph.test.ts
@@ -80,19 +80,28 @@ describe('Graph', () => {
     });
   });
 
-  it.skip('handles circular cycles', () => {
+  it('errors for circular cycles (order)', () => {
     const graph = new Graph([
-      { name: 'foo', dependencies: { bar: '0.0.0' } },
+      { name: 'foo', dependencies: { baz: '0.0.0' } },
       { name: 'bar', dependencies: { foo: '0.0.0' } },
+      { name: 'baz', dependencies: { bar: '0.0.0' } },
     ]);
 
-    console.log(graph);
+    expect(() => {
+      graph.resolveInOrder();
+    }).toThrowError('Circular cycle detected: foo -> bar -> baz -> foo');
+  });
 
-    expect(graph.resolveInOrder()).toEqual([]);
-    expect(graph.resolveTree()).toEqual({
-      root: true,
-      nodes: [],
-    });
+  it('errors for circular cycles (tree)', () => {
+    const graph = new Graph([
+      { name: 'foo', dependencies: { baz: '0.0.0' } },
+      { name: 'bar', dependencies: { foo: '0.0.0' } },
+      { name: 'baz', dependencies: { bar: '0.0.0' } },
+    ]);
+
+    expect(() => {
+      graph.resolveTree();
+    }).toThrowError('Circular cycle detected: foo -> bar -> baz -> foo');
   });
 
   it('returns an empty array when no packages are defined', () => {

--- a/packages/dependency-graph/tests/Graph.test.ts
+++ b/packages/dependency-graph/tests/Graph.test.ts
@@ -20,7 +20,7 @@ describe('Graph', () => {
     const pkgs = getBeemoPackages();
     const graph = new Graph(Object.values(pkgs));
 
-    expect(graph.resolveInOrder()).toEqual([
+    expect(graph.resolveList()).toEqual([
       pkgs['@beemo/dependency-graph'],
       pkgs['@beemo/core'],
       pkgs['@beemo/driver-babel'],
@@ -83,7 +83,7 @@ describe('Graph', () => {
   it('returns an empty array when no packages are defined', () => {
     const graph = new Graph();
 
-    expect(graph.resolveInOrder()).toEqual([]);
+    expect(graph.resolveList()).toEqual([]);
     expect(graph.resolveTree()).toEqual({
       root: true,
       nodes: [],
@@ -93,7 +93,7 @@ describe('Graph', () => {
   it('places all nodes at the root if they do not relate to each other', () => {
     const graph = new Graph([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]);
 
-    expect(graph.resolveInOrder()).toEqual([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]);
+    expect(graph.resolveList()).toEqual([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]);
     expect(graph.resolveTree()).toEqual({
       root: true,
       nodes: [
@@ -113,7 +113,7 @@ describe('Graph', () => {
   it('maps dependencies between 2 packages', () => {
     const graph = new Graph([{ name: 'foo' }, { name: 'bar', dependencies: { foo: '0.0.0' } }]);
 
-    expect(graph.resolveInOrder()).toEqual([
+    expect(graph.resolveList()).toEqual([
       { name: 'foo' },
       { name: 'bar', dependencies: { foo: '0.0.0' } },
     ]);
@@ -135,7 +135,7 @@ describe('Graph', () => {
   it('maps dependencies between 2 packages (reverse order + peer deps)', () => {
     const graph = new Graph([{ name: 'foo', peerDependencies: { bar: '0.0.0' } }, { name: 'bar' }]);
 
-    expect(graph.resolveInOrder()).toEqual([
+    expect(graph.resolveList()).toEqual([
       { name: 'bar' },
       { name: 'foo', peerDependencies: { bar: '0.0.0' } },
     ]);
@@ -161,7 +161,7 @@ describe('Graph', () => {
       { name: 'baz' },
     ]);
 
-    expect(graph.resolveInOrder()).toEqual([
+    expect(graph.resolveList()).toEqual([
       { name: 'baz' },
       { name: 'bar' },
       { name: 'foo', dependencies: { baz: '0.0.0' } },
@@ -191,7 +191,7 @@ describe('Graph', () => {
       { name: 'baz' },
     ]);
 
-    expect(graph.resolveInOrder()).toEqual([
+    expect(graph.resolveList()).toEqual([
       { name: 'baz' },
       { name: 'bar', dependencies: { baz: '0.0.0' } },
       { name: 'foo', dependencies: { bar: '0.0.0' } },
@@ -227,7 +227,7 @@ describe('Graph', () => {
       { name: 'k', dependencies: { f: '0.0.0' } },
     ]);
 
-    expect(graph.resolveInOrder()).toEqual([
+    expect(graph.resolveList()).toEqual([
       { name: 'b' },
       { name: 'a' },
       { name: 'c' },
@@ -301,7 +301,7 @@ describe('Graph', () => {
       { name: 'utils', dependencies: { core: '0.0.0' } },
     ]);
 
-    expect(graph.resolveInOrder()).toEqual([
+    expect(graph.resolveList()).toEqual([
       { name: 'icons' },
       { name: 'core', dependencies: { icons: '0.0.0' } },
       { name: 'utils', dependencies: { core: '0.0.0' } },
@@ -340,12 +340,12 @@ describe('Graph', () => {
   it('resets the graph when a package is added after resolution', () => {
     const graph = new Graph<PackageConfig>([{ name: 'foo' }, { name: 'bar' }]);
 
-    expect(graph.resolveInOrder()).toEqual([{ name: 'foo' }, { name: 'bar' }]);
+    expect(graph.resolveList()).toEqual([{ name: 'foo' }, { name: 'bar' }]);
 
     graph.addPackage({ name: 'qux', dependencies: { baz: '0.0.0' } });
     graph.addPackage({ name: 'baz', dependencies: { foo: '0.0.0' } });
 
-    expect(graph.resolveInOrder()).toEqual([
+    expect(graph.resolveList()).toEqual([
       { name: 'foo' },
       { name: 'bar' },
       { name: 'baz', dependencies: { foo: '0.0.0' } },
@@ -363,7 +363,7 @@ describe('Graph', () => {
         ]);
 
         expect(() => {
-          graph.resolveInOrder();
+          graph.resolveList();
         }).toThrowError('Circular dependency detected: foo -> bar -> baz -> foo');
       });
 
@@ -375,7 +375,7 @@ describe('Graph', () => {
         ]);
 
         expect(() => {
-          graph.resolveInOrder();
+          graph.resolveList();
         }).toThrowError('Circular dependency detected: foo -> bar -> foo');
       });
     });

--- a/packages/dependency-graph/tests/Graph.test.ts
+++ b/packages/dependency-graph/tests/Graph.test.ts
@@ -80,30 +80,6 @@ describe('Graph', () => {
     });
   });
 
-  it('errors for circular cycles (order)', () => {
-    const graph = new Graph([
-      { name: 'foo', dependencies: { baz: '0.0.0' } },
-      { name: 'bar', dependencies: { foo: '0.0.0' } },
-      { name: 'baz', dependencies: { bar: '0.0.0' } },
-    ]);
-
-    expect(() => {
-      graph.resolveInOrder();
-    }).toThrowError('Circular cycle detected: foo -> bar -> baz -> foo');
-  });
-
-  it('errors for circular cycles (tree)', () => {
-    const graph = new Graph([
-      { name: 'foo', dependencies: { baz: '0.0.0' } },
-      { name: 'bar', dependencies: { foo: '0.0.0' } },
-      { name: 'baz', dependencies: { bar: '0.0.0' } },
-    ]);
-
-    expect(() => {
-      graph.resolveTree();
-    }).toThrowError('Circular cycle detected: foo -> bar -> baz -> foo');
-  });
-
   it('returns an empty array when no packages are defined', () => {
     const graph = new Graph();
 
@@ -375,5 +351,59 @@ describe('Graph', () => {
       { name: 'baz', dependencies: { foo: '0.0.0' } },
       { name: 'qux', dependencies: { baz: '0.0.0' } },
     ]);
+  });
+
+  describe('circular', () => {
+    describe('list', () => {
+      it('errors when no root nodes found', () => {
+        const graph = new Graph([
+          { name: 'foo', dependencies: { baz: '0.0.0' } },
+          { name: 'bar', dependencies: { foo: '0.0.0' } },
+          { name: 'baz', dependencies: { bar: '0.0.0' } },
+        ]);
+
+        expect(() => {
+          graph.resolveInOrder();
+        }).toThrowError('Circular dependency detected: foo -> bar -> baz -> foo');
+      });
+
+      it('errors when only some of the deps are a cycle', () => {
+        const graph = new Graph([
+          { name: 'foo', dependencies: { bar: '0.0.0' } },
+          { name: 'bar', dependencies: { foo: '0.0.0' } },
+          { name: 'baz' },
+        ]);
+
+        expect(() => {
+          graph.resolveInOrder();
+        }).toThrowError('Circular dependency detected: foo -> bar -> foo');
+      });
+    });
+
+    describe('tree', () => {
+      it('errors when no root nodes found', () => {
+        const graph = new Graph([
+          { name: 'foo', dependencies: { baz: '0.0.0' } },
+          { name: 'bar', dependencies: { foo: '0.0.0' } },
+          { name: 'baz', dependencies: { bar: '0.0.0' } },
+        ]);
+
+        expect(() => {
+          graph.resolveTree();
+        }).toThrowError('Circular dependency detected: foo -> bar -> baz -> foo');
+      });
+
+      it('errors when only some of the deps are a cycle', () => {
+        const graph = new Graph([
+          { name: 'foo', dependencies: { bar: '0.0.0' } },
+          { name: 'bar', dependencies: { foo: '0.0.0' } },
+          { name: 'baz' },
+        ]);
+
+        expect(() => {
+          graph.resolveTree();
+        }).toThrowError('Circular dependency detected: foo -> bar -> foo');
+      });
+    });
   });
 });

--- a/packages/dependency-graph/tests/Graph.test.ts
+++ b/packages/dependency-graph/tests/Graph.test.ts
@@ -21,8 +21,8 @@ describe('Graph', () => {
     const graph = new Graph(Object.values(pkgs));
 
     expect(graph.resolveInOrder()).toEqual([
-      pkgs['@beemo/core'],
       pkgs['@beemo/dependency-graph'],
+      pkgs['@beemo/core'],
       pkgs['@beemo/cli'],
       pkgs['@beemo/driver-babel'],
       pkgs['@beemo/driver-eslint'],
@@ -38,50 +38,51 @@ describe('Graph', () => {
       root: true,
       nodes: [
         {
-          package: pkgs['@beemo/core'],
+          package: pkgs['@beemo/dependency-graph'],
           nodes: [
             {
-              leaf: true,
-              package: pkgs['@beemo/cli'],
-            },
-            {
-              package: pkgs['@beemo/driver-babel'],
+              package: pkgs['@beemo/core'],
               nodes: [
                 {
                   leaf: true,
-                  package: pkgs['@beemo/driver-jest'],
+                  package: pkgs['@beemo/cli'],
+                },
+                {
+                  package: pkgs['@beemo/driver-babel'],
+                  nodes: [
+                    {
+                      leaf: true,
+                      package: pkgs['@beemo/driver-jest'],
+                    },
+                  ],
+                },
+                {
+                  leaf: true,
+                  package: pkgs['@beemo/driver-eslint'],
+                },
+                {
+                  leaf: true,
+                  package: pkgs['@beemo/driver-flow'],
+                },
+                {
+                  leaf: true,
+                  package: pkgs['@beemo/driver-mocha'],
+                },
+                {
+                  leaf: true,
+                  package: pkgs['@beemo/driver-prettier'],
+                },
+                {
+                  leaf: true,
+                  package: pkgs['@beemo/driver-typescript'],
+                },
+                {
+                  leaf: true,
+                  package: pkgs['@beemo/driver-webpack'],
                 },
               ],
             },
-            {
-              leaf: true,
-              package: pkgs['@beemo/driver-eslint'],
-            },
-            {
-              leaf: true,
-              package: pkgs['@beemo/driver-flow'],
-            },
-            {
-              leaf: true,
-              package: pkgs['@beemo/driver-mocha'],
-            },
-            {
-              leaf: true,
-              package: pkgs['@beemo/driver-prettier'],
-            },
-            {
-              leaf: true,
-              package: pkgs['@beemo/driver-typescript'],
-            },
-            {
-              leaf: true,
-              package: pkgs['@beemo/driver-webpack'],
-            },
           ],
-        },
-        {
-          leaf: true,
-          package: pkgs['@beemo/dependency-graph'],
         },
       ],
     });
@@ -242,7 +243,7 @@ describe('Graph', () => {
   });
 
   it('resets the graph when a package is added after resolution', () => {
-    const graph = new Graph([{ name: 'foo' }, { name: 'bar' }]);
+    const graph = new Graph<PackageConfig>([{ name: 'foo' }, { name: 'bar' }]);
 
     expect(graph.resolveInOrder()).toEqual([{ name: 'foo' }, { name: 'bar' }]);
 

--- a/scripts/RunIntegrationTests.js
+++ b/scripts/RunIntegrationTests.js
@@ -23,7 +23,7 @@ module.exports = class RunIntegrationTestsScript extends Script {
       throw new Error('Please pass one of --fail or --pass.');
     }
 
-    const pkg = fs.readJsonSync(path.join(context.root, 'package.json'));
+    const pkg = fs.readJsonSync(path.join(context.cwd, 'package.json'));
     const name = pkg.name.split('/')[1];
     const script = pkg.scripts && pkg.scripts[`integration:${key}`];
 
@@ -38,7 +38,7 @@ module.exports = class RunIntegrationTestsScript extends Script {
     return Promise.all(
       script.split('&&').map(command =>
         execa
-          .shell(command.trim(), { cwd: context.root })
+          .shell(command.trim(), { cwd: context.cwd })
           // Handles everything else
           .then(response => this.handleResult(name, options, response))
           // Handles syntax errors


### PR DESCRIPTION
Have been unable to find an existing package that determines the dependency graph based on a list of defined `package.json`s, and thus, this package is born.

- [x] Implement graph and nodes
- [x] Update routine to use graph
- [x] Detect circular cycles
- [x] Add more complex tests

Solves #32 