### PR TITLE
Add test for complex dependency graph

### DIFF
--- a/packages/core/src/execute/BaseRoutine.ts
+++ b/packages/core/src/execute/BaseRoutine.ts
@@ -60,6 +60,15 @@ export default abstract class BaseRoutine<Ctx extends Context<BaseContextArgs>> 
       this.formatAndThrowErrors(errors);
     }
 
+    if (context.args.workspaces) {
+      const results: any[] = [];
+
+      responses.forEach(response => results.push(...response.results));
+
+      return results;
+    }
+
+    // Not running in workspaces, so return value directly
     return responses[0].results[0];
   }
 

--- a/packages/core/src/execute/BaseRoutine.ts
+++ b/packages/core/src/execute/BaseRoutine.ts
@@ -1,5 +1,5 @@
-import { Routine, WorkspacePackageConfig } from '@boost/core';
-import Graph, { TreeNode } from '@beemo/dependency-graph';
+import { Routine, WorkspacePackageConfig, AggregatedResponse } from '@boost/core';
+import Graph from '@beemo/dependency-graph';
 import Context from '../contexts/Context';
 import isPatternMatch from '../utils/isPatternMatch';
 import { BeemoTool } from '../types';
@@ -38,19 +38,29 @@ export default abstract class BaseRoutine<Ctx extends Context<BaseContextArgs>> 
 
   async execute(context: Ctx): Promise<any[]> {
     const value = await this.serializeTasks();
-    const { other, priority } = this.orderByWorkspacePriorityGraph();
-
-    await this.serializeRoutines(value, priority);
+    const batches = this.orderByWorkspacePriorityGraph();
+    const errors: Error[] = [];
 
     const concurrency = context.args.concurrency || this.tool.config.execute.concurrency;
-    const response = await this.poolRoutines(value, concurrency ? { concurrency } : {}, other);
+    const responses: AggregatedResponse[] = [];
 
-    if (response.errors.length > 0) {
-      this.formatAndThrowErrors(response.errors);
+    // eslint-disable-next-line no-restricted-syntax
+    for (const batch of batches) {
+      // eslint-disable-next-line no-await-in-loop
+      const response = await this.poolRoutines(value, concurrency ? { concurrency } : {}, batch);
+
+      responses.push(response);
+
+      if (response.errors.length > 0) {
+        errors.push(...response.errors);
+      }
     }
 
-    // Not running in workspaces, so return value directly
-    return context.args.workspaces ? response.results : response.results[0];
+    if (errors.length > 0) {
+      this.formatAndThrowErrors(errors);
+    }
+
+    return responses[0].results[0];
   }
 
   /**
@@ -79,45 +89,25 @@ export default abstract class BaseRoutine<Ctx extends Context<BaseContextArgs>> 
   /**
    * Group routines in order of which they are dependend on.
    */
-  orderByWorkspacePriorityGraph(): {
-    other: Routine<Ctx, BeemoTool>[];
-    priority: Routine<Ctx, BeemoTool>[];
-  } {
+  orderByWorkspacePriorityGraph(): Routine<Ctx, BeemoTool>[][] {
     const enabled = this.context.args.priority || this.tool.config.execute.priority;
 
     if (!enabled || !this.context.args.workspaces) {
-      return {
-        other: this.routines,
-        priority: [],
-      };
+      return [this.routines];
     }
 
-    const tree = new Graph(this.workspacePackages).resolveTree();
-    const priority: Routine<Ctx, BeemoTool>[] = [];
-    const other: Routine<Ctx, BeemoTool>[] = [];
+    const batchList = new Graph(this.workspacePackages).resolveBatchList();
+    const batches: Routine<Ctx, BeemoTool>[][] = [];
 
-    const handler = (node: TreeNode<WorkspacePackageConfig>) => {
-      const routine = this.routines.find(route => route.key === node.package.workspace.packageName);
+    batchList.forEach(batch => {
+      const routines = batch
+        .map(pkg => this.routines.find(route => route.key === pkg.workspace.packageName))
+        .filter(Boolean) as Routine<Ctx, BeemoTool>[];
 
-      if (routine) {
-        if (node.nodes) {
-          priority.push(routine);
-        } else {
-          other.push(routine);
-        }
-      }
+      batches.push(routines);
+    });
 
-      if (node.nodes) {
-        node.nodes.forEach(childNode => handler(childNode));
-      }
-    };
-
-    tree.nodes.forEach(node => handler(node));
-
-    return {
-      other,
-      priority,
-    };
+    return batches;
   }
 
   /**

--- a/packages/core/tests/execute/BaseRoutine.test.ts
+++ b/packages/core/tests/execute/BaseRoutine.test.ts
@@ -144,7 +144,7 @@ describe('BaseExecuteRoutine', () => {
       it('returns an array of results for multiple routines', async () => {
         const response = await routine.execute(routine.context);
 
-        expect(response).toEqual(['primary', 'foo', 'bar', 'baz', 'qux']);
+        expect(response.sort()).toEqual(['bar', 'baz', 'foo', 'primary', 'qux']);
       });
 
       it('serializes priority routines before pooling other routines', async () => {
@@ -261,7 +261,7 @@ describe('BaseExecuteRoutine', () => {
     });
 
     it('returns all in single batch if no dependents', () => {
-      expect(routine.orderByWorkspacePriorityGraph()).toEqual([[primary, foo, bar, baz, qux]]);
+      expect(routine.orderByWorkspacePriorityGraph()).toEqual([[bar, baz, foo, primary, qux]]);
     });
 
     it('prioritizes based on peerDependencies', () => {
@@ -270,7 +270,7 @@ describe('BaseExecuteRoutine', () => {
         '@scope/bar': '1.0.0',
       };
 
-      expect(routine.orderByWorkspacePriorityGraph()).toEqual([[primary, bar, baz, qux], [foo]]);
+      expect(routine.orderByWorkspacePriorityGraph()).toEqual([[bar, baz, primary, qux], [foo]]);
     });
 
     it('prioritizes based on dependencies', () => {
@@ -279,7 +279,7 @@ describe('BaseExecuteRoutine', () => {
         '@scope/bar': '1.0.0',
       };
 
-      expect(routine.orderByWorkspacePriorityGraph()).toEqual([[primary, bar, baz, qux], [foo]]);
+      expect(routine.orderByWorkspacePriorityGraph()).toEqual([[bar, baz, primary, qux], [foo]]);
     });
 
     it('sorts priority based on dependency count', () => {

--- a/packages/dependency-graph/src/Graph.ts
+++ b/packages/dependency-graph/src/Graph.ts
@@ -146,10 +146,10 @@ export default class Graph<T extends PackageConfig = PackageConfig> {
       });
 
       if (nextBatch.length === 0) {
-        throw new Error('Could not build dependency batches, some packages are unreachable');
+        this.detectCycle();
       }
 
-      batches.push(nextBatch.map(node => this.packages.get(node.name)!));
+      batches.push(this.sortByDependedOn(nextBatch).map(node => this.packages.get(node.name)!));
       nextBatch.forEach(node => seen.add(node));
 
       if (seen.size !== this.nodes.size) {

--- a/packages/dependency-graph/src/Graph.ts
+++ b/packages/dependency-graph/src/Graph.ts
@@ -240,9 +240,17 @@ export default class Graph<T extends PackageConfig = PackageConfig> {
   }
 
   /**
-   * Sort a set of nodes by most depended on.
+   * Sort a set of nodes by most depended on, fall back to alpha sort as tie breaker
    */
   protected sortByDependedOn(nodes: Set<Node> | Node[]): Node[] {
-    return [...nodes].sort((a, b) => b.dependents.size - a.dependents.size);
+    return [...nodes].sort((a, b) => {
+      const diff = b.dependents.size - a.dependents.size;
+
+      if (diff === 0) {
+        return a.name > b.name ? 1 : -1;
+      }
+
+      return diff;
+    });
   }
 }

--- a/packages/dependency-graph/tests/Graph.test.ts
+++ b/packages/dependency-graph/tests/Graph.test.ts
@@ -34,6 +34,22 @@ describe('Graph', () => {
       pkgs['@beemo/driver-webpack'],
     ]);
 
+    expect(graph.resolveBatchList()).toEqual([
+      [pkgs['@beemo/dependency-graph']],
+      [pkgs['@beemo/core']],
+      [
+        pkgs['@beemo/driver-babel'],
+        pkgs['@beemo/cli'],
+        pkgs['@beemo/driver-eslint'],
+        pkgs['@beemo/driver-flow'],
+        pkgs['@beemo/driver-mocha'],
+        pkgs['@beemo/driver-prettier'],
+        pkgs['@beemo/driver-typescript'],
+        pkgs['@beemo/driver-webpack'],
+      ],
+      [pkgs['@beemo/driver-jest']],
+    ]);
+
     expect(graph.resolveTree()).toEqual({
       root: true,
       nodes: [
@@ -94,6 +110,7 @@ describe('Graph', () => {
     const graph = new Graph([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]);
 
     expect(graph.resolveList()).toEqual([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]);
+    expect(graph.resolveBatchList()).toEqual([[{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]]);
     expect(graph.resolveTree()).toEqual({
       root: true,
       nodes: [
@@ -117,6 +134,10 @@ describe('Graph', () => {
       { name: 'foo' },
       { name: 'bar', dependencies: { foo: '0.0.0' } },
     ]);
+    expect(graph.resolveBatchList()).toEqual([
+      [{ name: 'foo' }],
+      [{ name: 'bar', dependencies: { foo: '0.0.0' } }],
+    ]);
     expect(graph.resolveTree()).toEqual({
       root: true,
       nodes: [
@@ -138,6 +159,10 @@ describe('Graph', () => {
     expect(graph.resolveList()).toEqual([
       { name: 'bar' },
       { name: 'foo', peerDependencies: { bar: '0.0.0' } },
+    ]);
+    expect(graph.resolveBatchList()).toEqual([
+      [{ name: 'bar' }],
+      [{ name: 'foo', peerDependencies: { bar: '0.0.0' } }],
     ]);
     expect(graph.resolveTree()).toEqual({
       root: true,
@@ -165,6 +190,10 @@ describe('Graph', () => {
       { name: 'baz' },
       { name: 'bar' },
       { name: 'foo', dependencies: { baz: '0.0.0' } },
+    ]);
+    expect(graph.resolveBatchList()).toEqual([
+      [{ name: 'baz' }, { name: 'bar' }],
+      [{ name: 'foo', dependencies: { baz: '0.0.0' } }],
     ]);
     expect(graph.resolveTree()).toEqual({
       root: true,
@@ -196,6 +225,13 @@ describe('Graph', () => {
       { name: 'bar', dependencies: { baz: '0.0.0' } },
       { name: 'foo', dependencies: { bar: '0.0.0' } },
     ]);
+
+    expect(graph.resolveBatchList()).toEqual([
+      [{ name: 'baz' }],
+      [{ name: 'bar', dependencies: { baz: '0.0.0' } }],
+      [{ name: 'foo', dependencies: { bar: '0.0.0' } }],
+    ]);
+
     expect(graph.resolveTree()).toEqual({
       root: true,
       nodes: [
@@ -210,6 +246,28 @@ describe('Graph', () => {
         },
       ],
     });
+  });
+
+  it('package with 2 dependencies', () => {
+    const graph = new Graph([
+      { name: 'foo' },
+      { name: 'bar', dependencies: { foo: '0.0.0' } },
+      { name: 'baz', dependencies: { foo: '0.0.0' } },
+    ]);
+
+    expect(graph.resolveList()).toEqual([
+      { name: 'foo' },
+      { name: 'bar', dependencies: { foo: '0.0.0' } },
+      { name: 'baz', dependencies: { foo: '0.0.0' } },
+    ]);
+
+    expect(graph.resolveBatchList()).toEqual([
+      [{ name: 'foo' }],
+      [
+        { name: 'bar', dependencies: { foo: '0.0.0' } },
+        { name: 'baz', dependencies: { foo: '0.0.0' } },
+      ],
+    ]);
   });
 
   it('sorts each depth by most dependend on', () => {
@@ -239,6 +297,20 @@ describe('Graph', () => {
       { name: 'k', dependencies: { f: '0.0.0' } },
       { name: 'i', dependencies: { k: '0.0.0' } },
       { name: 'e', dependencies: { i: '0.0.0' } },
+    ]);
+
+    expect(graph.resolveBatchList()).toEqual([
+      [{ name: 'b' }, { name: 'a' }, { name: 'c' }],
+      [
+        { name: 'f', peerDependencies: { b: '0.0.0' } },
+        { name: 'd', dependencies: { b: '0.0.0' } },
+        { name: 'g', dependencies: { a: '0.0.0' } },
+        { name: 'h', dependencies: { b: '0.0.0' } },
+        { name: 'j', peerDependencies: { c: '0.0.0' } },
+      ],
+      [{ name: 'k', dependencies: { f: '0.0.0' } }],
+      [{ name: 'i', dependencies: { k: '0.0.0' } }],
+      [{ name: 'e', dependencies: { i: '0.0.0' } }],
     ]);
     expect(graph.resolveTree()).toEqual({
       root: true,
@@ -309,6 +381,16 @@ describe('Graph', () => {
       { name: 'forms', dependencies: { core: '0.0.0' } },
     ]);
 
+    expect(graph.resolveBatchList()).toEqual([
+      [{ name: 'icons' }],
+      [{ name: 'core', dependencies: { icons: '0.0.0' } }],
+      [
+        { name: 'utils', dependencies: { core: '0.0.0' } },
+        { name: 'forms', dependencies: { core: '0.0.0' } },
+      ],
+      [{ name: 'helpers', dependencies: { core: '0.0.0', utils: '0.0.0' } }],
+    ]);
+
     expect(graph.resolveTree()).toEqual({
       root: true,
       nodes: [
@@ -354,12 +436,12 @@ describe('Graph', () => {
     expect(graph.resolveBatchList()).toEqual([
       [{ name: 'stats', dependencies: {} }, { name: 'config', dependencies: {} }],
       [
-        { name: 'feature-flags', dependencies: { config: '0.0.0' } },
         { name: 'http-client', dependencies: { stats: '0.0.0' } },
+        { name: 'feature-flags', dependencies: { config: '0.0.0' } },
       ],
       [
-        { name: 'service-client', dependencies: { stats: '0.0.0', 'http-client': '0.0.0' } },
         { name: 'auth-client', dependencies: { stats: '0.0.0', 'http-client': '0.0.0' } },
+        { name: 'service-client', dependencies: { stats: '0.0.0', 'http-client': '0.0.0' } },
       ],
       [
         {
@@ -383,6 +465,12 @@ describe('Graph', () => {
       { name: 'bar' },
       { name: 'baz', dependencies: { foo: '0.0.0' } },
       { name: 'qux', dependencies: { baz: '0.0.0' } },
+    ]);
+
+    expect(graph.resolveBatchList()).toEqual([
+      [{ name: 'foo' }, { name: 'bar' }],
+      [{ name: 'baz', dependencies: { foo: '0.0.0' } }],
+      [{ name: 'qux', dependencies: { baz: '0.0.0' } }],
     ]);
   });
 
@@ -435,6 +523,32 @@ describe('Graph', () => {
 
         expect(() => {
           graph.resolveTree();
+        }).toThrowError('Circular dependency detected: foo -> bar -> foo');
+      });
+    });
+
+    describe('batchList', () => {
+      it('errors when no root nodes found', () => {
+        const graph = new Graph([
+          { name: 'foo', dependencies: { baz: '0.0.0' } },
+          { name: 'bar', dependencies: { foo: '0.0.0' } },
+          { name: 'baz', dependencies: { bar: '0.0.0' } },
+        ]);
+
+        expect(() => {
+          graph.resolveBatchList();
+        }).toThrowError('Circular dependency detected: foo -> bar -> baz -> foo');
+      });
+
+      it('errors when only some of the deps are a cycle', () => {
+        const graph = new Graph([
+          { name: 'foo', dependencies: { bar: '0.0.0' } },
+          { name: 'bar', dependencies: { foo: '0.0.0' } },
+          { name: 'baz' },
+        ]);
+
+        expect(() => {
+          graph.resolveBatchList();
         }).toThrowError('Circular dependency detected: foo -> bar -> foo');
       });
     });

--- a/packages/dependency-graph/tests/Graph.test.ts
+++ b/packages/dependency-graph/tests/Graph.test.ts
@@ -351,74 +351,23 @@ describe('Graph', () => {
       { name: 'http-client', dependencies: { stats: '0.0.0' } },
     ]);
 
-    expect(graph.resolveList()).toEqual([
-      { name: 'stats', dependencies: {} },
-      { name: 'config', dependencies: {} },
-      { name: 'feature-flags', dependencies: { config: '0.0.0' } },
-      { name: 'http-client', dependencies: { stats: '0.0.0' } },
-      { name: 'auth-client', dependencies: { stats: '0.0.0', 'http-client': '0.0.0' } },
-      { name: 'service-client', dependencies: { stats: '0.0.0', 'http-client': '0.0.0' } },
-      {
-        name: 'framework',
-        dependencies: { stats: '0.0.0', 'auth-client': '0.0.0', 'feature-flags': '0.0.0' },
-      },
-    ]);
-
-    expect(graph.resolveTree()).toEqual({
-      root: true,
-      nodes: [
+    expect(graph.resolveBatchList()).toEqual([
+      [{ name: 'stats', dependencies: {} }, { name: 'config', dependencies: {} }],
+      [
+        { name: 'feature-flags', dependencies: { config: '0.0.0' } },
+        { name: 'http-client', dependencies: { stats: '0.0.0' } },
+      ],
+      [
+        { name: 'service-client', dependencies: { stats: '0.0.0', 'http-client': '0.0.0' } },
+        { name: 'auth-client', dependencies: { stats: '0.0.0', 'http-client': '0.0.0' } },
+      ],
+      [
         {
-          package: { name: 'stats', dependencies: {} },
-          nodes: [
-            {
-              package: { name: 'http-client', dependencies: { stats: '0.0.0' } },
-              nodes: [
-                {
-                  package: {
-                    name: 'auth-client',
-                    dependencies: { stats: '0.0.0', 'http-client': '0.0.0' },
-                  },
-                  nodes: [
-                    {
-                      package: {
-                        name: 'framework',
-                        dependencies: {
-                          stats: '0.0.0',
-                          'auth-client': '0.0.0',
-                          'feature-flags': '0.0.0',
-                        },
-                      },
-                    },
-                  ],
-                },
-                {
-                  package: {
-                    name: 'service-client',
-                    dependencies: { stats: '0.0.0', 'http-client': '0.0.0' },
-                  },
-                },
-              ],
-            },
-          ],
-        },
-        {
-          package: { name: 'config', dependencies: {} },
-          nodes: [
-            {
-              package: { name: 'feature-flags', dependencies: { config: '0.0.0' } },
-              nodes: [
-                {
-                  package: {
-                    name: 'service-client',
-                    dependencies: { stats: '0.0.0', 'http-client': '0.0.0' },
-                  },
-                },
-              ],
-            },
-          ],
+          name: 'framework',
+          dependencies: { stats: '0.0.0', 'auth-client': '0.0.0', 'feature-flags': '0.0.0' },
         },
       ],
-    });
+    ]);
   });
 
   it('resets the graph when a package is added after resolution', () => {

--- a/packages/dependency-graph/tests/Graph.test.ts
+++ b/packages/dependency-graph/tests/Graph.test.ts
@@ -109,19 +109,19 @@ describe('Graph', () => {
   it('places all nodes at the root if they do not relate to each other', () => {
     const graph = new Graph([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]);
 
-    expect(graph.resolveList()).toEqual([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]);
-    expect(graph.resolveBatchList()).toEqual([[{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]]);
+    expect(graph.resolveList()).toEqual([{ name: 'bar' }, { name: 'baz' }, { name: 'foo' }]);
+    expect(graph.resolveBatchList()).toEqual([[{ name: 'bar' }, { name: 'baz' }, { name: 'foo' }]]);
     expect(graph.resolveTree()).toEqual({
       root: true,
       nodes: [
-        {
-          package: { name: 'foo' },
-        },
         {
           package: { name: 'bar' },
         },
         {
           package: { name: 'baz' },
+        },
+        {
+          package: { name: 'foo' },
         },
       ],
     });
@@ -455,7 +455,7 @@ describe('Graph', () => {
   it('resets the graph when a package is added after resolution', () => {
     const graph = new Graph<PackageConfig>([{ name: 'foo' }, { name: 'bar' }]);
 
-    expect(graph.resolveList()).toEqual([{ name: 'foo' }, { name: 'bar' }]);
+    expect(graph.resolveList()).toEqual([{ name: 'bar' }, { name: 'foo' }]);
 
     graph.addPackage({ name: 'qux', dependencies: { baz: '0.0.0' } });
     graph.addPackage({ name: 'baz', dependencies: { foo: '0.0.0' } });

--- a/packages/dependency-graph/tests/Graph.test.ts
+++ b/packages/dependency-graph/tests/Graph.test.ts
@@ -337,6 +337,90 @@ describe('Graph', () => {
     });
   });
 
+  it('orders correctly with complex dependencies', () => {
+    const graph = new Graph([
+      { name: 'stats', dependencies: {} },
+      { name: 'service-client', dependencies: { stats: '0.0.0', 'http-client': '0.0.0' } },
+      { name: 'auth-client', dependencies: { stats: '0.0.0', 'http-client': '0.0.0' } },
+      { name: 'config', dependencies: {} },
+      { name: 'feature-flags', dependencies: { config: '0.0.0' } },
+      {
+        name: 'framework',
+        dependencies: { stats: '0.0.0', 'auth-client': '0.0.0', 'feature-flags': '0.0.0' },
+      },
+      { name: 'http-client', dependencies: { stats: '0.0.0' } },
+    ]);
+
+    expect(graph.resolveList()).toEqual([
+      { name: 'stats', dependencies: {} },
+      { name: 'config', dependencies: {} },
+      { name: 'feature-flags', dependencies: { config: '0.0.0' } },
+      { name: 'http-client', dependencies: { stats: '0.0.0' } },
+      { name: 'auth-client', dependencies: { stats: '0.0.0', 'http-client': '0.0.0' } },
+      { name: 'service-client', dependencies: { stats: '0.0.0', 'http-client': '0.0.0' } },
+      {
+        name: 'framework',
+        dependencies: { stats: '0.0.0', 'auth-client': '0.0.0', 'feature-flags': '0.0.0' },
+      },
+    ]);
+
+    expect(graph.resolveTree()).toEqual({
+      root: true,
+      nodes: [
+        {
+          package: { name: 'stats', dependencies: {} },
+          nodes: [
+            {
+              package: { name: 'http-client', dependencies: { stats: '0.0.0' } },
+              nodes: [
+                {
+                  package: {
+                    name: 'auth-client',
+                    dependencies: { stats: '0.0.0', 'http-client': '0.0.0' },
+                  },
+                  nodes: [
+                    {
+                      package: {
+                        name: 'framework',
+                        dependencies: {
+                          stats: '0.0.0',
+                          'auth-client': '0.0.0',
+                          'feature-flags': '0.0.0',
+                        },
+                      },
+                    },
+                  ],
+                },
+                {
+                  package: {
+                    name: 'service-client',
+                    dependencies: { stats: '0.0.0', 'http-client': '0.0.0' },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          package: { name: 'config', dependencies: {} },
+          nodes: [
+            {
+              package: { name: 'feature-flags', dependencies: { config: '0.0.0' } },
+              nodes: [
+                {
+                  package: {
+                    name: 'service-client',
+                    dependencies: { stats: '0.0.0', 'http-client': '0.0.0' },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('resets the graph when a package is added after resolution', () => {
     const graph = new Graph<PackageConfig>([{ name: 'foo' }, { name: 'bar' }]);
 

--- a/packages/dependency-graph/tests/Graph.test.ts
+++ b/packages/dependency-graph/tests/Graph.test.ts
@@ -27,11 +27,11 @@ describe('Graph', () => {
       pkgs['@beemo/cli'],
       pkgs['@beemo/driver-eslint'],
       pkgs['@beemo/driver-flow'],
-      pkgs['@beemo/driver-jest'],
       pkgs['@beemo/driver-mocha'],
       pkgs['@beemo/driver-prettier'],
       pkgs['@beemo/driver-typescript'],
       pkgs['@beemo/driver-webpack'],
+      pkgs['@beemo/driver-jest'],
     ]);
 
     expect(graph.resolveBatchList()).toEqual([
@@ -291,8 +291,8 @@ describe('Graph', () => {
       { name: 'c' },
       { name: 'f', peerDependencies: { b: '0.0.0' } },
       { name: 'd', dependencies: { b: '0.0.0' } },
-      { name: 'h', dependencies: { b: '0.0.0' } },
       { name: 'g', dependencies: { a: '0.0.0' } },
+      { name: 'h', dependencies: { b: '0.0.0' } },
       { name: 'j', peerDependencies: { c: '0.0.0' } },
       { name: 'k', dependencies: { f: '0.0.0' } },
       { name: 'i', dependencies: { k: '0.0.0' } },
@@ -377,8 +377,8 @@ describe('Graph', () => {
       { name: 'icons' },
       { name: 'core', dependencies: { icons: '0.0.0' } },
       { name: 'utils', dependencies: { core: '0.0.0' } },
-      { name: 'helpers', dependencies: { core: '0.0.0', utils: '0.0.0' } },
       { name: 'forms', dependencies: { core: '0.0.0' } },
+      { name: 'helpers', dependencies: { core: '0.0.0', utils: '0.0.0' } },
     ]);
 
     expect(graph.resolveBatchList()).toEqual([


### PR DESCRIPTION
Test for a dependency graph that currently fails.

The test doesn't really have the right shape for the expected tree, because the expected result can't be cleanly represented as tree without making the it very suboptimal. 

The underlying issue is that this uses a tree to represent a graph, so if a package depends on 2 packages, which don't depend on each other, the tree can't be built correctly. 