### PR TITLE
update: Use module resolution for config module bootstrapping.

### DIFF
--- a/packages/core/src/Beemo.ts
+++ b/packages/core/src/Beemo.ts
@@ -103,21 +103,26 @@ export default class Beemo extends Tool<BeemoPluginRegistry, BeemoConfig> {
   bootstrapConfigModule() {
     this.debug('Bootstrapping configuration module');
 
-    const moduleRoot = this.getConfigModuleRoot();
-    const indexPath = moduleRoot.append('index.js');
+    const { module } = this.config;
+    let bootstrap: Function | null = null;
 
-    if (!indexPath.exists()) {
+    try {
+      if (module === '@local') {
+        bootstrap = requireModule(this.getConfigModuleRoot().append('index.js'));
+      } else {
+        bootstrap = requireModule(module);
+      }
+    } catch {
       this.debug('No index.js file detected, aborting bootstrap');
 
       return this;
     }
 
-    const bootstrap = requireModule<Function>(indexPath);
     const isFunction = typeof bootstrap === 'function';
 
     this.debug.invariant(isFunction, 'Executing bootstrap function', 'Found', 'Not found');
 
-    if (isFunction) {
+    if (bootstrap && isFunction) {
       bootstrap(this);
     }
 

--- a/packages/core/tests/Beemo.test.ts
+++ b/packages/core/tests/Beemo.test.ts
@@ -15,8 +15,6 @@ import {
   stubScaffoldArgs,
   stubScriptArgs,
 } from '../src/testUtils';
-// @ts-ignore
-import bootstrapIndex from '../../../tests';
 
 // Can't use spyOn here because its not a real object.
 /* eslint-disable jest/prefer-spy-on */
@@ -32,19 +30,14 @@ jest.mock(
 );
 /* eslint-enable jest/prefer-spy-on */
 
-jest.mock('../../../tests', () => jest.fn());
-
-const root = Path.resolve('../../../tests', __dirname);
+jest.mock('fake-bootstrap-module', () => jest.fn(), { virtual: true });
 
 describe('Beemo', () => {
   let beemo: Beemo;
 
   beforeEach(() => {
     beemo = mockTool(['foo', 'bar']);
-    beemo.moduleRoot = root;
-    beemo.options.root = root.path();
-
-    (bootstrapIndex as jest.Mock).mockReset();
+    beemo.moduleRoot = new Path(beemo.options.root);
   });
 
   it('sets argv', () => {
@@ -53,13 +46,16 @@ describe('Beemo', () => {
 
   describe('bootstrapConfigModule()', () => {
     beforeEach(() => {
-      beemo.config.module = '@local';
+      beemo.config.module = 'fake-bootstrap-module';
     });
 
     it('calls bootstrap with tool if index exists', () => {
+      // eslint-disable-next-line
+      const bootstrap = require('fake-bootstrap-module');
+
       beemo.bootstrapConfigModule();
 
-      expect(bootstrapIndex).toHaveBeenCalledWith(beemo);
+      expect(bootstrap).toHaveBeenCalledWith(beemo);
     });
   });
 
@@ -340,8 +336,6 @@ describe('Beemo', () => {
         expect.objectContaining({
           args: stubArgs(),
           argv: ['foo', 'bar'],
-          moduleRoot: root,
-          cwd: root,
         }),
       );
     });

--- a/packages/core/tests/routines/driver/ExecuteCommandRoutine.test.ts
+++ b/packages/core/tests/routines/driver/ExecuteCommandRoutine.test.ts
@@ -461,7 +461,7 @@ describe('ExecuteCommandRoutine', () => {
     it('converts globs to paths', async () => {
       const args = await routine.expandGlobPatterns(routine.context, [
         '--foo',
-        '../{scripts,tests}/*.{sh,js}',
+        '../{scripts,tests}/*.js',
         'bar',
       ]);
 
@@ -473,7 +473,6 @@ describe('ExecuteCommandRoutine', () => {
         '../scripts/BumpPeerDeps.js',
         '../scripts/RunIntegrationTests.js',
         '../scripts/extractOptionList.js',
-        '../tests/index.js',
         'bar',
       ]);
     });

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,2 +1,0 @@
-// Example bootstrap file for tests
-module.exports = {};


### PR DESCRIPTION
The previous bootstrapping implementation would check for an `index.js` file manually within the config module. This works... but completely circumvents the Node.js module resolution, which would also check against `package.json`, and `main`, etc.

This change will rely on the resolution when not `@local`.