### PR TITLE
new: Improve error output for failed drivers and scripts.

### DIFF
--- a/packages/core/resources/en/errors.json
+++ b/packages/core/resources/en/errors.json
@@ -4,6 +4,7 @@
   "configReferenceSourceMissing": "Cannot reference configuration file. Source file does not exist in configuration module.",
   "configNoFunction": "Configuration file \"{{name}}\" returned a function. Only plain objects are supported.",
   "executeFailed": "Failed to execute pipeline. The following errors have occurred:",
+  "executeFailedMoreLines": "… {{count}} more lines …",
   "executeTypeUnknown": "Unknown execution type {{type}}.",
   "eslintIgnoreInvalid": "Ignore configuration must be an array of strings.",
   "moduleConfigMissing": "Beemo requires a \"{{configName}}.module\" property within your package.json. This property is the name of a module that houses your configuration files.",

--- a/packages/core/src/Driver.ts
+++ b/packages/core/src/Driver.ts
@@ -13,7 +13,14 @@ import {
   STRATEGY_NATIVE,
   STRATEGY_NONE,
 } from './constants';
-import { Argv, DriverCommandOptions, DriverOptions, DriverMetadata, Execution } from './types';
+import {
+  Argv,
+  DriverCommandOptions,
+  DriverOptions,
+  DriverMetadata,
+  Execution,
+  ExecutionError,
+} from './types';
 
 export default abstract class Driver<
   Config extends object = {},
@@ -77,7 +84,7 @@ export default abstract class Driver<
   /**
    * Extract the error message when the driver fails to execute.
    */
-  extractErrorMessage(error: Error): string {
+  extractErrorMessage(error: ExecutionError): string {
     return error.message.split('\n', 1)[0] || '';
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { Task, ToolConfig, ToolPluginRegistry, PluginSetting } from '@boost/core';
-import { ExecaReturnValue } from 'execa';
+import { ExecaReturnValue, ExecaError } from 'execa';
 import { Arguments, Options } from 'yargs';
 import Beemo from './Beemo';
 import Driver from './Driver';
@@ -61,6 +61,8 @@ export interface DriverMetadata {
 }
 
 export type Execution = ExecaReturnValue;
+
+export type ExecutionError = ExecaError;
 
 export type ExecuteType = 'parallel' | 'pool' | 'serial' | 'sync';
 

--- a/packages/core/tests/routines/RunInWorkspacesRoutine.test.ts
+++ b/packages/core/tests/routines/RunInWorkspacesRoutine.test.ts
@@ -116,20 +116,22 @@ describe('RunInWorkspacesRoutine', () => {
     });
 
     it('throws an error if any failures', async () => {
-      jest
-        .spyOn(routine, 'poolRoutines')
-        .mockImplementation(() =>
-          Promise.resolve({ errors: [new Error('Failed'), new Error('Oops')], results: [] }),
-        );
+      jest.spyOn(routine, 'poolRoutines').mockImplementation(() => {
+        const a = new Error('Failed');
+        // @ts-ignore
+        a.stdout = 'Stdout info...';
+
+        const b = new Error('Oops');
+        // @ts-ignore
+        b.stderr = 'Stderr message!';
+
+        return Promise.resolve({ errors: [a, b], results: [] });
+      });
 
       try {
         await routine.execute(routine.context);
       } catch (error) {
-        expect(error).toEqual(
-          new Error(
-            'Failed to execute pipeline. The following errors have occurred:\n\nFailed\n\nOops',
-          ),
-        );
+        expect(error).toMatchSnapshot();
       }
     });
 

--- a/packages/core/tests/routines/__snapshots__/RunInWorkspacesRoutine.test.ts.snap
+++ b/packages/core/tests/routines/__snapshots__/RunInWorkspacesRoutine.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RunInWorkspacesRoutine execute() throws an error if any failures 1`] = `
+[Error: Failed to execute pipeline. The following errors have occurred:
+
+[0m[33mFailed[39m[0m
+[0m[90mStdout info...[39m[0m
+
+[0m[33mOops[39m[0m
+[0m[90mStderr message![39m[0m
+]
+`;

--- a/packages/driver-babel/package.json
+++ b/packages/driver-babel/package.json
@@ -11,7 +11,7 @@
     "compile"
   ],
   "scripts": {
-    "integration:fail": "babel ./integration/fail.js && babel ./integration/fail-syntax.js",
+    "integration:fail": "babel ./integration/fail.js && babel ./integration/fail-syntax.js && babel --invalid-option",
     "integration:pass": "babel ./integration/pass.js"
   },
   "main": "./lib/index.js",

--- a/packages/driver-babel/src/BabelDriver.ts
+++ b/packages/driver-babel/src/BabelDriver.ts
@@ -1,5 +1,5 @@
 import rimraf from 'rimraf';
-import { Driver, DriverArgs, DriverContext, Path } from '@beemo/core';
+import { Driver, DriverArgs, DriverContext, Path, ExecutionError } from '@beemo/core';
 import { BabelArgs, BabelConfig } from './types';
 
 // Success: Writes file list to stdout
@@ -26,7 +26,7 @@ export default class BabelDriver extends Driver<BabelConfig> {
     this.onBeforeExecute.listen(this.handleCleanTarget);
   }
 
-  extractErrorMessage(error: Error): string {
+  extractErrorMessage(error: ExecutionError): string {
     if (error.message.includes('SyntaxError')) {
       return error.message.split(/|\s+at/u, 1)[0];
     }

--- a/packages/driver-eslint/package.json
+++ b/packages/driver-eslint/package.json
@@ -11,7 +11,7 @@
     "linter"
   ],
   "scripts": {
-    "integration:fail": "eslint ./integration/fail.js ./integration/fail-syntax.js",
+    "integration:fail": "eslint ./integration/fail.js ./integration/fail-syntax.js && eslint --invalid-option",
     "integration:pass": "eslint ./integration/pass.js"
   },
   "main": "./lib/index.js",

--- a/packages/driver-flow/package.json
+++ b/packages/driver-flow/package.json
@@ -11,7 +11,7 @@
     "type"
   ],
   "scripts": {
-    "integration:fail": "flow check --flowconfig-name .flowconfig.fail",
+    "integration:fail": "flow check --flowconfig-name .flowconfig.fail && flow --invalid-option",
     "integration:pass": "flow check --flowconfig-name .flowconfig.pass"
   },
   "main": "./lib/index.js",

--- a/packages/driver-jest/package.json
+++ b/packages/driver-jest/package.json
@@ -11,7 +11,7 @@
     "runner"
   ],
   "scripts": {
-    "integration:fail": "jest ./integration/fail.test.js",
+    "integration:fail": "jest ./integration/fail.test.js && jest --invalid-option",
     "integration:pass": "jest ./integration/pass.test.js"
   },
   "main": "./lib/index.js",

--- a/packages/driver-mocha/package.json
+++ b/packages/driver-mocha/package.json
@@ -11,7 +11,7 @@
     "runner"
   ],
   "scripts": {
-    "integration:fail": "mocha ./integration/fail.js",
+    "integration:fail": "mocha ./integration/fail.js && mocha --invalid-option",
     "integration:pass": "mocha ./integration/pass.js"
   },
   "main": "./lib/index.js",

--- a/packages/driver-prettier/package.json
+++ b/packages/driver-prettier/package.json
@@ -11,7 +11,7 @@
     "formatter"
   ],
   "scripts": {
-    "integration:fail": "prettier ./integration/fail.js",
+    "integration:fail": "prettier ./integration/fail.js && prettier ./integration/fail.js --invalid-option",
     "integration:pass": "prettier ./integration/pass.js"
   },
   "main": "./lib/index.js",

--- a/packages/driver-prettier/src/PrettierDriver.ts
+++ b/packages/driver-prettier/src/PrettierDriver.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { Event } from '@boost/event';
-import { Driver, ConfigContext, ConfigArgs, Path } from '@beemo/core';
+import { Driver, ConfigContext, ConfigArgs, Path, ExecutionError } from '@beemo/core';
 import { PrettierArgs, PrettierConfig } from './types';
 
 // Success: Writes file list to stdout
@@ -21,7 +21,7 @@ export default class PrettierDriver extends Driver<PrettierConfig> {
     this.onCreateConfigFile.listen(this.handleCreateIgnoreFile);
   }
 
-  extractErrorMessage(error: Error): string {
+  extractErrorMessage(error: ExecutionError): string {
     if (error.message.includes('SyntaxError')) {
       return error.message.split(/|\s+$/u, 1)[0];
     }

--- a/packages/driver-typescript/package.json
+++ b/packages/driver-typescript/package.json
@@ -10,7 +10,7 @@
     "type"
   ],
   "scripts": {
-    "integration:fail": "tsc --noEmit ./integration/fail.ts ./integration/fail-syntax.ts",
+    "integration:fail": "tsc --noEmit ./integration/fail.ts ./integration/fail-syntax.ts && tsc --invalid-option",
     "integration:pass": "tsc --noEmit ./integration/pass.ts ./integration/pass-untyped.ts"
   },
   "main": "./lib/index.js",

--- a/packages/driver-webpack/package.json
+++ b/packages/driver-webpack/package.json
@@ -10,7 +10,7 @@
     "bundler"
   ],
   "scripts": {
-    "integration:fail": "webpack --mode development ./integration/fail.js",
+    "integration:fail": "webpack --mode development ./integration/fail.js && webpack --invalid-option",
     "integration:pass": "webpack --mode development ./integration/pass.js"
   },
   "main": "./lib/index.js",

--- a/packages/driver-webpack/src/WebpackDriver.ts
+++ b/packages/driver-webpack/src/WebpackDriver.ts
@@ -1,4 +1,4 @@
-import { Driver, STRATEGY_REFERENCE } from '@beemo/core';
+import { Driver, ExecutionError, STRATEGY_REFERENCE } from '@beemo/core';
 import { WebpackConfig } from './types';
 
 // Success: Writes passed tests to stdout
@@ -15,7 +15,7 @@ export default class WebpackDriver extends Driver<WebpackConfig> {
     });
   }
 
-  extractErrorMessage(error: Error): string {
+  extractErrorMessage(error: ExecutionError): string {
     if (error.message.indexOf('|') > 0) {
       return error.message.split(/|\s+at$/u, 1)[0];
     }


### PR DESCRIPTION
Our current error reporting loses information, especially when run against a workspace, as there are multiple errors with different stack traces. Currently we combine all the messages and re-throw a single error, which is unfortunate.

This new approach does something similar, but also persists `stderr` and `stdout` if it's been defined (as the error message is always useless coming from execa). It looks like the following.

<img width="600" alt="Screen Shot 2019-12-07 at 16 41 48" src="https://user-images.githubusercontent.com/143744/70382472-a4e79400-1911-11ea-8887-e82cf6c4f6cc.png">

Fixes #71 