### PR TITLE
Make debug a dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,13 +36,13 @@
   "dependencies": {
     "@boost/cli": "^2.10.1",
     "ink": "^3.0.8",
-    "react": "^16.13.1"
+    "react": "^16.13.1",
+    "debug": "^4.3.1"
   },
   "peerDependencies": {
     "@beemo/core": "^2.0.0-alpha.0"
   },
   "devDependencies": {
-    "debug": "^4.3.1",
     "time-require": "^0.1.2"
   },
   "funding": {


### PR DESCRIPTION
Otherwise I get this error with yarn 2:

Error: @beemo/cli tried to access debug, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.